### PR TITLE
Disables Circuits + Stops crashing

### DIFF
--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -108,8 +108,8 @@
 
 
 /obj/item/integrated_circuit_printer/interact(mob/user)
-	//if(!(in_range(src, user) || issilicon(user)))
-	return
+	if(!(in_range(src, user) || issilicon(user)))
+		return
 
 	var/client/client = user.client
 	if (CONFIG_GET(flag/use_exp_tracking) && client && client.get_exp_living(TRUE) < 480) // Player with less than 8 hours playtime is using this machine.

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -104,11 +104,12 @@
 	return ..()
 
 /obj/item/integrated_circuit_printer/attack_self(mob/user)
-	interact(user)
+	return
+
 
 /obj/item/integrated_circuit_printer/interact(mob/user)
-	if(!(in_range(src, user) || issilicon(user)))
-		return
+	//if(!(in_range(src, user) || issilicon(user)))
+	return
 
 	var/client/client = user.client
 	if (CONFIG_GET(flag/use_exp_tracking) && client && client.get_exp_living(TRUE) < 480) // Player with less than 8 hours playtime is using this machine.

--- a/modular_sand/code/game/objects/items/fleshlight.dm
+++ b/modular_sand/code/game/objects/items/fleshlight.dm
@@ -346,7 +346,7 @@
 // portal fleshlight box
 /obj/item/storage/box/portallight/PopulateContents()
 	new /obj/item/portallight/(src)
-	new /obj/item/clothing/underwear/briefs/panties/portalpanties/(src)
+	//new /obj/item/clothing/underwear/briefs/panties/portalpanties/(src)
 	new /obj/item/paper/fluff/portallight(src)
 
 /obj/item/paper/fluff/portallight

--- a/modular_sand/code/game/objects/items/fleshlight.dm
+++ b/modular_sand/code/game/objects/items/fleshlight.dm
@@ -239,6 +239,7 @@
  * # Hyperstation 13 portal underwear
  * Wear it, cannot be worn if not pointing to the bits you have.
 */
+
 /obj/item/clothing/underwear/briefs/panties/portalpanties
 	name = "portal panties"
 	desc = "A silver love(TM) pair of portal underwear, with bluespace tech allows lovers to hump at a distance. Needs to be paired with a portal fleshlight before use."

--- a/modular_sand/code/modules/vending/kinkmate.dm
+++ b/modular_sand/code/modules/vending/kinkmate.dm
@@ -1,5 +1,5 @@
 /obj/machinery/vending/kink/Initialize()
 	products += list(/obj/item/clothing/under/costume/loincloth = 4,
 					/obj/item/fleshlight = 4,
-//					/obj/item/storage/box/portallight = 4)
+					/obj/item/storage/box/portallight = 4)
 	. = ..()

--- a/modular_sand/code/modules/vending/kinkmate.dm
+++ b/modular_sand/code/modules/vending/kinkmate.dm
@@ -1,5 +1,5 @@
 /obj/machinery/vending/kink/Initialize()
 	products += list(/obj/item/clothing/under/costume/loincloth = 4,
 					/obj/item/fleshlight = 4,
-					/obj/item/storage/box/portallight = 4)
+//					/obj/item/storage/box/portallight = 4)
 	. = ..()


### PR DESCRIPTION
# About The Pull Request

Disables circuits. If you want circuits back, you can update them to 2022 /tg/ standards.

## Why It's Good For The Game

Circuits are unfiltered. They are a massive server security concern. 

Portal panties are crashing the server. These will need to be fixed.

## Changelog

:cl: Curiosity
del: Disables Circuits
/:cl:

